### PR TITLE
Update to .NET 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple In-App Purchase plugin for .NET MAUI and Windows to query item informat
 Subscriptions are supported on iOS, Android, and Mac. Windows/UWP/WinUI 3 - does not support subscriptions at this time.
 
 ## Important Version Information
-* v8 now supports .NET 8+ .NET MAUI and Windows Apps.
+* v9 now supports .NET 9+ .NET MAUI and Windows Apps.
 * v7 now supports .NET 6+, .NET MAUI, UWP, and Xamarin/Xamarin.Forms projects
 * v7 is built against Android Billing Library 6.0
 * See migration guides below
@@ -33,10 +33,10 @@ Get started by reading through the [In-App Billing Plugin documentation](https:/
 * Podcast: [Merge Conflict](http://mergeconflict.fm)
 * Videos: [James's YouTube Channel](https://www.youtube.com/jamesmontemagno) 
 
-## Version 8 Major Updates
+## Version 9 Major Updates
 * Nice new re-write and re-implementation of APIs!
-* Built against .NET 8
-* Now using latest Android Billing v6.2.1
+* Built against .NET 9
+* Now using latest Android Billing v7.1.1
 
 ## Version 7 Major Updates
 * Android: You must compile and target against Android 12 or higher  (or Android 13 if v7.1)

--- a/src/InAppBillingTests/InAppBillingMauiTest/InAppBillingMauiTest.csproj
+++ b/src/InAppBillingTests/InAppBillingMauiTest/InAppBillingMauiTest.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
+    <TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net9.0-windows10.0.19041</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>InAppBillingMauiTest</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -20,9 +20,9 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>
 
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-ios'">14.2</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net9.0-android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
   </PropertyGroup>

--- a/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
+++ b/src/Plugin.InAppBilling/Plugin.InAppBilling.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net9.0-maccatalyst;net9.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <UseMaui Condition="'$(TargetFramework)' != 'net8.0'">true</UseMaui>
-    <UseMauiEssentials Condition="'$(TargetFramework)' != 'net8.0'">true</UseMauiEssentials>
+    <UseMaui Condition="'$(TargetFramework)' != 'net9.0'">true</UseMaui>
+    <UseMauiEssentials Condition="'$(TargetFramework)' != 'net9.0'">true</UseMauiEssentials>
     <SingleProject>true</SingleProject>
     <AssemblyName>Plugin.InAppBilling</AssemblyName>
     <RootNamespace>Plugin.InAppBilling</RootNamespace>
@@ -95,7 +95,7 @@
 
   <ItemGroup Condition=" $(TargetFramework.Contains('-android')) ">
     <PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" />
-    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="6.2.1" />
+    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="7.1.1.4" />
     <PackageReference Include="Xamarin.AndroidX.Activity">
       <Version>1.9.0.4</Version>
     </PackageReference>
@@ -160,7 +160,7 @@
   <ItemGroup Condition=" $(TargetFramework.Contains('-android')) ">
     <Compile Include="**\*.android.cs" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiVersion)" />
-    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="6.2.1" />
+    <PackageReference Include="Xamarin.Android.Google.BillingClient" Version="7.1.1.4" />
     --><!--<PackageReference Include="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.19"/>--><!--
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- target .NET 9 frameworks
- update Android Billing library
- note .NET 9 support in docs

## Testing
- `dotnet restore src/InAppBilling.sln` *(fails: Microsoft.iOS.Sdk.net9.0 workload not found)*


------
https://chatgpt.com/codex/tasks/task_e_6851aabbb030832ebd7ec069a16c5672